### PR TITLE
CDI-26 Bootstrap support

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -95,6 +95,17 @@
 			</roles>
 			<email>mkouba[at]redhat[dot]com</email>
 		</developer>
+
+        <developer>
+            <name>John D. Ament</name>
+            <id>johndament</id>
+            <organization>Independent</organization>
+            <timezone>EST</timezone>
+            <roles>
+                <role>JCP Member</role>
+            </roles>
+            <email>johndament[at]apache[dot]org</email>
+        </developer>
 	</developers>
 
 
@@ -216,6 +227,7 @@
 			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
+                <version>2.5.3</version>
 				<executions>
 					<execution>
 						<id>bundle-manifest</id>
@@ -228,8 +240,8 @@
 				<configuration>
 					<instructions>
 						<Export-Package>
-							javax.decorator;version=1.1,
-							javax.enterprise.*;version=1.1,
+							javax.decorator;version=2.0,
+							javax.enterprise.*;version=2.0,
 						</Export-Package>
 						<Import-Package>
 							javax.el; version=2.2,

--- a/api/src/main/java/javax/enterprise/inject/spi/CDI.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/CDI.java
@@ -9,6 +9,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -21,7 +22,7 @@ import javax.enterprise.inject.Instance;
  * @author Pete Muir
  * @since 1.1
  */
-public abstract class CDI<T> implements Instance<T> {
+public abstract class CDI<T> implements Instance<T>, AutoCloseable {
 
     protected static volatile Set<CDIProvider> discoveredProviders = null;
     protected static volatile CDIProvider configuredProvider = null;
@@ -42,30 +43,7 @@ public abstract class CDI<T> implements Instance<T> {
      * 
      */
     public static CDI<Object> current() {
-        if (configuredProvider != null) {
-            return configuredProvider.getCDI();
-        } else {
-
-            // Discover providers and cache
-            if (discoveredProviders == null) {
-                synchronized (lock) {
-                    if (discoveredProviders == null) {
-                        findAllProviders();
-                    }
-                }
-            }
-
-            CDI<Object> cdi = null;
-            for (CDIProvider provider : discoveredProviders) {
-                cdi = provider.getCDI();
-                if (cdi != null)
-                    break;
-            }
-            if (cdi == null) {
-                throw new IllegalStateException("Unable to access CDI");
-            }
-            return cdi;
-        }
+        return getCDIProvider().getCDI();
     }
 
     /**
@@ -81,11 +59,50 @@ public abstract class CDI<T> implements Instance<T> {
      * @throws IllegalStateException if the {@link CDIProvider} is already set
      */
     public static void setCDIProvider(CDIProvider provider) {
-        if (configuredProvider == null) {
+        if (provider != null) {
             configuredProvider = provider;
         } else {
-            throw new IllegalStateException("CDIProvider has already been set");
+            throw new IllegalStateException("CDIProvider must not be null");
         }
+    }
+
+    /**
+     * Retrieves the {@link CDIProvider}.  If one is already configured, uses that.
+     * If {@link #setCDIProvider} was called first, the provider populated there is returned.  Otherwise a
+     * {@link java.util.ServiceLoader} is used to locate a provider.
+     * @return the configured {@link CDIProvider} or a discovered {@link CDIProvider}.
+     */
+    public static CDIProvider getCDIProvider() {
+        if (configuredProvider != null) {
+            return configuredProvider;
+        } else {
+            // Discover providers and cache
+            if (discoveredProviders == null) {
+                synchronized (lock) {
+                    if (discoveredProviders == null) {
+                        findAllProviders();
+                    }
+                }
+            }
+            configuredProvider = discoveredProviders.stream()
+                    .filter(CDI::notNull).findFirst()
+                    .orElseThrow(() -> new IllegalStateException("Unable to locate CDIProvider"));
+            return configuredProvider;
+        }
+    }
+
+    /**
+     * Shuts down the current CDI instance.  Cannot be invoked within an application server or if the container is not
+     * already started.  If called in either of these ways, an {@link java.lang.IllegalStateException} is thrown.
+     */
+    public abstract void shutdown();
+
+    /**
+     * Implemented from {@link AutoCloseable}, shuts down the current CDI instance when it is no longer in scope.
+     */
+    @Override
+    public void close() {
+        this.shutdown();
     }
 
     // Helper methods
@@ -142,6 +159,10 @@ public abstract class CDI<T> implements Instance<T> {
             }
         }
         return names;
+    }
+
+    private static boolean notNull(Object o) {
+        return o != null;
     }
 
     /**

--- a/api/src/main/java/javax/enterprise/inject/spi/CDI.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/CDI.java
@@ -9,7 +9,7 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
-import java.util.Optional;
+import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -85,7 +85,7 @@ public abstract class CDI<T> implements Instance<T>, AutoCloseable {
                 }
             }
             configuredProvider = discoveredProviders.stream()
-                    .filter(CDI::notNull).findFirst()
+                    .filter(Objects::nonNull).findFirst()
                     .orElseThrow(() -> new IllegalStateException("Unable to locate CDIProvider"));
             return configuredProvider;
         }
@@ -159,10 +159,6 @@ public abstract class CDI<T> implements Instance<T>, AutoCloseable {
             }
         }
         return names;
-    }
-
-    private static boolean notNull(Object o) {
-        return o != null;
     }
 
     /**

--- a/api/src/main/java/javax/enterprise/inject/spi/CDIProvider.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/CDIProvider.java
@@ -1,5 +1,8 @@
 package javax.enterprise.inject.spi;
 
+import java.util.Collections;
+import java.util.Map;
+
 /**
  * Interface implemented by a CDI provider to provide access to the current container
  * 
@@ -14,5 +17,32 @@ public interface CDIProvider {
      * @return the CDI instance for the current container
      */
     public CDI<Object> getCDI();
+
+    /**
+     * Determines whether or not this CDIProvider has been initialized or not.
+     * @return true if initialized, false if not.
+     */
+    boolean isInitialized();
+
+    /**
+     * Initializes a CDI Container.  Cannot be called within an application server or if the container is already started.
+     * If called in either of these ways, an {@link java.lang.IllegalStateException} is thrown.
+     *
+     * @return the {@link CDI} instance associated with the container.  This is the same instance returned by using
+     * {@link CDI.current()}
+     */
+    default CDI<Object> initialize() {
+        return initialize(Collections.EMPTY_MAP);
+    }
+
+    /**
+     * Initializes a CDI Container.  Cannot be called within an application server or if the container is already started.
+     * If called in either of these ways, an {@link java.lang.IllegalStateException} is thrown.
+     *
+     * @param params optional parameters, may be null or empty.  May also be immutable.
+     * @return the {@link CDI} instance associated with the container.  This is the same instance returned by using
+     * {@link CDI.current()}
+     */
+    CDI<Object> initialize(Map<String,Object> params);
 
 }

--- a/api/src/main/java/javax/enterprise/inject/spi/CDIProvider.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/CDIProvider.java
@@ -16,7 +16,7 @@ public interface CDIProvider {
      * 
      * @return the CDI instance for the current container
      */
-    public CDI<Object> getCDI();
+    CDI<Object> getCDI();
 
     /**
      * Determines whether or not this CDIProvider has been initialized or not.
@@ -25,8 +25,8 @@ public interface CDIProvider {
     boolean isInitialized();
 
     /**
-     * Initializes a CDI Container.  Cannot be called within an application server or if the container is already started.
-     * If called in either of these ways, an {@link java.lang.IllegalStateException} is thrown.
+     * Initializes a CDI Container.  Cannot be called within an application server.
+     * If called in this way, an {@link java.lang.UnsupportedOperationException} is thrown.
      *
      * @return the {@link CDI} instance associated with the container.  This is the same instance returned by using
      * {@link CDI.current()}
@@ -36,8 +36,8 @@ public interface CDIProvider {
     }
 
     /**
-     * Initializes a CDI Container.  Cannot be called within an application server or if the container is already started.
-     * If called in either of these ways, an {@link java.lang.IllegalStateException} is thrown.
+     * Initializes a CDI Container.  Cannot be called within an application server.
+     * If called in this way, an {@link java.lang.UnsupportedOperationException} is thrown.
      *
      * @param params optional parameters, may be null or empty.  May also be immutable.
      * @return the {@link CDI} instance associated with the container.  This is the same instance returned by using

--- a/spec/src/main/doc/cdi-se.asciidoc
+++ b/spec/src/main/doc/cdi-se.asciidoc
@@ -23,7 +23,7 @@ The `CDI` utility class provides static lookup for `CDIProvider` instances based
 
 The `CDIProvider` instance returned is capable of starting a `CDI` instance.  By invoking either of the  `initialize` methods it can start up a container to retriever beans, fire events, gain access to the `BeanManager`.  The `initialize` methods on the `CDIProvider` interface must not be invoked when in an EE container.  If they are invoked, an `UnsupportedOperationException` shall be thrown.  Likewise, if `shutdown` or `close` were invoked on the `CDI` class while in an EE container, an `UnsupportedOperationException` shall also be thrown.
 
-Calling `initialize` on the `CDIProvider` has the effect of creating a new `CDI` instance each time invoked.
+Calling `initialize` on the `CDIProvider` has the effect of creating a new `CDI` instance each time invoked.  The _application context_ is started automatically by the container on start up.
 
 The `CDI` can be stopped when it's not needed.  To help with this, `CDI` implements `AutoCloseable`, so when derefenced it should shutdown automatically (the `close` method invokes `shutdown`).  You must also shutdown the CDI instance manually by calling the `shutdown` method on the CDI object.  If the `shutdown` method is explicitly invoked, it shall throw an `IllegalStateException` if the container was never initialized or if it was already shutdown.  The `close` method should not throw an `IllegalStateException` if the container was never initialized.
 

--- a/spec/src/main/doc/cdi-se.asciidoc
+++ b/spec/src/main/doc/cdi-se.asciidoc
@@ -1,0 +1,51 @@
+[[cdi-se]]
+
+== Using CDI in Java SE Applications
+
+=== Bootstrapping a container
+
+In Java EE, CDI comes enabled by default in your application, but if you're working with a Java SE application you can bootstrap a CDI container yourself to enable dependency injection.
+
+[source,java]
+----
+public static void main(String... args) {
+    CDIProvider provider = CDI.getCDIProvider();
+    CDI<Object> cdi = container.initialize();
+    // retrieve a bean and do work with it
+    MyBean myBean = cdi.select(MyBean.class).get();
+    myBean.doWork();
+    // when done
+    cdi.shutdown();
+}
+----
+
+The `CDI` utility class provides static lookup for `CDIProvider` instances based on `ServiceLoader` (this doesn't preclude the notion of manually instantiating the provider in a non-portable manner).  By default, the provider will be looked up via a ServiceLoader but can be over-written by calling `setCDIProvider` on the utility.  Once a `CDIProvider` has been located, it should not be instantiated again, instead the same one returned again.
+
+The `CDIProvider` instance returned is capable of starting a `CDI` instance.  By invoking either of the  `initialize` methods it can start up a container to retriever beans, fire events, gain access to the `BeanManager`.  The `initialize` methods on the `CDIProvider` interface must not be invoked when in an EE container.  If they are invoked, an `UnsupportedOperationException` may be thrown.  Likewise, if `shutdown` or `close` were invoked on the `CDI` class while in an EE container, an `UnsupportedOperationException` may also be thrown.
+
+Only a single `CDI` instance may be initialized within an SE application at a time, based on the provider used.  If a container has already been initialized and you call `initialize` again, an `IllegalStateException` is thrown.  If you manually instantiate a `CDIProvider` and initialize it, non-portable behavior may occur.
+
+The `CDI` can be stopped when it's not needed.  To help with this, `CDI` implements `AutoCloseable`, so when derefenced it should shutdown automatically (the `close` method invokes `shutdown`).  You may also shutdown the CDI instance manually by calling the `shutdown` method on the CDI object.  If the `shutdown` method is explicitly invoked, it may throw an `IllegalStateException` if the container was never initialized or if it was already shutdown.  The `close` method should not throw an `IllegalStateException` if the container was never initialized.
+
+Due to that, the following code block is equivalent to the above example:
+
+[source,java]
+----
+public static void main(String... args) {
+    try(CDI cdi = CDI.getCDIProvider().initialize()) {
+        // start the container, retrieve a bean and do work with it
+        MyBean myBean = cdi.select(MyBean.class).get();
+        myBean.doWork();
+    }
+    // shuts down automatically after the try with resources block.
+}
+----
+
+=== Classpath Scanning
+
+All classpath entries in a Java SE application are considered to be at the same level.  All rules that apply to bean resolution based on `beans.xml` declaration continue to apply the same way in Java SE.
+
+* If a classpath entry contains a `META-INF/beans.xml` with `bean-discovery-mode=annotated` or does not contain a `META-INF/beans.xml` then only the annotated beans will be scanned within that entry.
+* If a classpath entry contains a `META-INF/beans.xml` with `bean-discovery-mode=all` then all classes will be scanned within that entry.
+* If a classpath entry contains a `META-INF/beans.xml` with `bean-discovery-mode=none` then no classes will be scanend within that entry.
+

--- a/spec/src/main/doc/cdi-se.asciidoc
+++ b/spec/src/main/doc/cdi-se.asciidoc
@@ -10,7 +10,7 @@ In Java EE, CDI comes enabled by default in your application, but if you're work
 ----
 public static void main(String... args) {
     CDIProvider provider = CDI.getCDIProvider();
-    CDI<Object> cdi = container.initialize();
+    CDI<Object> cdi = provider.initialize();
     // retrieve a bean and do work with it
     MyBean myBean = cdi.select(MyBean.class).get();
     myBean.doWork();
@@ -21,18 +21,18 @@ public static void main(String... args) {
 
 The `CDI` utility class provides static lookup for `CDIProvider` instances based on `ServiceLoader` (this doesn't preclude the notion of manually instantiating the provider in a non-portable manner).  By default, the provider will be looked up via a ServiceLoader but can be over-written by calling `setCDIProvider` on the utility.  Once a `CDIProvider` has been located, it should not be instantiated again, instead the same one returned again.
 
-The `CDIProvider` instance returned is capable of starting a `CDI` instance.  By invoking either of the  `initialize` methods it can start up a container to retriever beans, fire events, gain access to the `BeanManager`.  The `initialize` methods on the `CDIProvider` interface must not be invoked when in an EE container.  If they are invoked, an `UnsupportedOperationException` may be thrown.  Likewise, if `shutdown` or `close` were invoked on the `CDI` class while in an EE container, an `UnsupportedOperationException` may also be thrown.
+The `CDIProvider` instance returned is capable of starting a `CDI` instance.  By invoking either of the  `initialize` methods it can start up a container to retriever beans, fire events, gain access to the `BeanManager`.  The `initialize` methods on the `CDIProvider` interface must not be invoked when in an EE container.  If they are invoked, an `UnsupportedOperationException` shall be thrown.  Likewise, if `shutdown` or `close` were invoked on the `CDI` class while in an EE container, an `UnsupportedOperationException` shall also be thrown.
 
-Only a single `CDI` instance may be initialized within an SE application at a time, based on the provider used.  If a container has already been initialized and you call `initialize` again, an `IllegalStateException` is thrown.  If you manually instantiate a `CDIProvider` and initialize it, non-portable behavior may occur.
+Calling `initialize` on the `CDIProvider` has the effect of creating a new `CDI` instance each time invoked.
 
-The `CDI` can be stopped when it's not needed.  To help with this, `CDI` implements `AutoCloseable`, so when derefenced it should shutdown automatically (the `close` method invokes `shutdown`).  You may also shutdown the CDI instance manually by calling the `shutdown` method on the CDI object.  If the `shutdown` method is explicitly invoked, it may throw an `IllegalStateException` if the container was never initialized or if it was already shutdown.  The `close` method should not throw an `IllegalStateException` if the container was never initialized.
+The `CDI` can be stopped when it's not needed.  To help with this, `CDI` implements `AutoCloseable`, so when derefenced it should shutdown automatically (the `close` method invokes `shutdown`).  You must also shutdown the CDI instance manually by calling the `shutdown` method on the CDI object.  If the `shutdown` method is explicitly invoked, it shall throw an `IllegalStateException` if the container was never initialized or if it was already shutdown.  The `close` method should not throw an `IllegalStateException` if the container was never initialized.
 
 Due to that, the following code block is equivalent to the above example:
 
 [source,java]
 ----
 public static void main(String... args) {
-    try(CDI cdi = CDI.getCDIProvider().initialize()) {
+    try(CDI<Object> cdi = CDI.getCDIProvider().initialize()) {
         // start the container, retrieve a bean and do work with it
         MyBean myBean = cdi.select(MyBean.class).get();
         myBean.doWork();

--- a/spec/src/main/doc/cdi-spec.asciidoc
+++ b/spec/src/main/doc/cdi-spec.asciidoc
@@ -25,6 +25,8 @@ include::interceptors.asciidoc[]
 
 include::events.asciidoc[]
 
+include::cdi-se.asciidoc[]
+
 include::spi.asciidoc[]
 
 include::packagingdeployment.asciidoc[]


### PR DESCRIPTION
Squashed commits:
[d005b5a] CDI-26 Cleaned up docs after EG review.
[4a86f00] CDI-26 Simplified try with resources example.
[e248ce4] CDI-26 Added docs for SE.
[a731d53] CDI-26 Added docs for SE.
[8d1c9d4] CDI-26 Close shouldn't have been throwing an exception.
[dd81e7a] CDI-26 Minor javadoc clean up.
[3115343] CDI-509 Updating pom file to use latest felix plugin.
[9db0748] CDI-26 Bootstrap API for CDI.