### PR TITLE
CDI-578 clarify the behaviour in various error cases

### DIFF
--- a/api/src/main/java/javax/enterprise/event/TransactionPhase.java
+++ b/api/src/main/java/javax/enterprise/event/TransactionPhase.java
@@ -26,10 +26,14 @@ package javax.enterprise.event;
  * Transactional observer methods are observer methods which receive event notifications during the before or after completion
  * phase of the transaction in which the event was fired. If no transaction is in progress when the event is fired, they are
  * notified at the same time as other observers.
+ * If the transaction is in an illegal state or already rolled back when the event is fired, the {@link #BEFORE_COMPLETION},
+ * {@link #AFTER_COMPLETION} and {@link #AFTER_FAILURE} observer methods are notified at the same time as other observers,
+ * but {@link #AFTER_SUCCESS} observer methods get skipped.
  * </p>
  * 
  * @author Pete Muir
  * @author Gavin King
+ * @author Mark Struberg
  * 
  */
 public enum TransactionPhase {
@@ -45,12 +49,30 @@ public enum TransactionPhase {
      * <p>
      * Identifies a before completion observer method, called during the before completion phase of the transaction.
      * </p>
+     * <p>
+     * It will also get invoked if
+     * <ul>
+     *     <li>there is no transaction in progress, or</li>
+     *     <li>the transaction already got rolled back, or</li>
+     *     <li>the transaction is marked for rollback, or</li>
+     *     <li>the transaction is in an illegal state.</li>
+     * </ul>
+     * </p>
      */
     BEFORE_COMPLETION,
 
     /**
      * <p>
      * Identifies an after completion observer method, called during the after completion phase of the transaction.
+     * </p>
+     * <p>
+     * It will also get invoked if
+     * <ul>
+     *     <li>there is no transaction in progress, or</li>
+     *     <li>the transaction already got rolled back, or</li>
+     *     <li>the transaction is marked for rollback, or</li>
+     *     <li>the transaction is in an illegal state.</li>
+     * </ul>
      * </p>
      */
     AFTER_COMPLETION,
@@ -60,6 +82,15 @@ public enum TransactionPhase {
      * Identifies an after failure observer method, called during the after completion phase of the transaction, only when the
      * transaction fails.
      * </p>
+     * <p>
+     * It will also get invoked if
+     * <ul>
+     *     <li>there is no transaction in progress, or</li>
+     *     <li>the transaction already got rolled back, or</li>
+     *     <li>the transaction is marked for rollback, or</li>
+     *     <li>the transaction is in an illegal state.</li>
+     * </ul>
+     * </p>
      */
     AFTER_FAILURE,
 
@@ -67,6 +98,9 @@ public enum TransactionPhase {
      * <p>
      * Identifies an after success observer method, called during the after completion phase of the transaction, only when the
      * transaction completes successfully.
+     * </p>
+     * <p>
+     * It will also get invoked if there is no transaction in progress.
      * </p>
      */
     AFTER_SUCCESS

--- a/spec/src/main/asciidoc/core/events.asciidoc
+++ b/spec/src/main/asciidoc/core/events.asciidoc
@@ -450,6 +450,7 @@ public enum Reception { IF_EXISTS, ALWAYS }
 
 _Transactional observer methods_ are observer methods which receive event notifications during the before or after completion phase of the transaction in which the event was fired.
 If no transaction is in progress when the event is fired, they are notified at the same time as other observers.
+If the transaction is in an illegal state or already rolled back when the event is fired, the _before completion_, _after completion_ and _after failure_ observer methods are notified at the same time as other observers, but _after_success_ observer methods get skipped.
 
 * A _before completion_ observer method is called during the before completion phase of the transaction.
 * An _after completion_ observer method is called during the after completion phase of the transaction.


### PR DESCRIPTION
on any error due to rollback and illegalstate:
- AFTER_SUCCESS only gets invoked immediately if there is no transaction active
- all other observers get invoked immediately

SystemException doesn't get treated in the spec. This indicates that there is some fundamental setup problem. So I think it's better to let the Exception blow out.
