### PR TITLE
CDI-588 More literals for built-in annotations

### DIFF
--- a/api/src/main/java/javax/enterprise/inject/Specializes.java
+++ b/api/src/main/java/javax/enterprise/inject/Specializes.java
@@ -25,6 +25,9 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import javax.enterprise.event.Event;
+import javax.enterprise.util.AnnotationLiteral;
+
 /**
  * <p>
  * Indicates that a bean directly specializes another bean. May be applied to a bean class or producer method.
@@ -67,4 +70,20 @@ import java.lang.annotation.Target;
 @Retention(RUNTIME)
 @Documented
 public @interface Specializes {
+    
+    /**
+     * Supports inline instantiation of the {@link Specializes} annotation.
+     *
+     * @author Martin Kouba
+     * @since 2.0
+     * @see Instance
+     * @see Event
+     */
+    public static final class Literal extends AnnotationLiteral<Specializes> implements Specializes {
+
+        private static final long serialVersionUID = 1L;
+
+        public static final Literal INSTANCE = new Literal();
+
+    }
 }

--- a/api/src/main/java/javax/enterprise/inject/TransientReference.java
+++ b/api/src/main/java/javax/enterprise/inject/TransientReference.java
@@ -24,6 +24,9 @@ import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import javax.enterprise.event.Event;
+import javax.enterprise.util.AnnotationLiteral;
+
 /**
  * <p>
  * If a parameter annotated with <tt>&#064;TransientReference</tt> resolves to a dependent scoped bean, then the bean will be
@@ -49,5 +52,21 @@ import java.lang.annotation.Target;
 @Retention(RUNTIME)
 @Documented
 public @interface TransientReference {
+    
+    /**
+     * Supports inline instantiation of the {@link TransientReference} annotation.
+     *
+     * @author Martin Kouba
+     * @since 2.0
+     * @see Instance
+     * @see Event
+     */
+    public static final class Literal extends AnnotationLiteral<TransientReference> implements TransientReference {
+
+        private static final long serialVersionUID = 1L;
+
+        public static final Literal INSTANCE = new Literal();
+
+    }
 
 }

--- a/api/src/main/java/javax/enterprise/inject/Vetoed.java
+++ b/api/src/main/java/javax/enterprise/inject/Vetoed.java
@@ -23,6 +23,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import javax.enterprise.event.Event;
+import javax.enterprise.util.AnnotationLiteral;
+
 /**
  * <p>
  * Veto the processing of the class. Any beans or observer methods defined by this class will not be installed.
@@ -46,5 +49,21 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Vetoed {
+
+    /**
+     * Supports inline instantiation of the {@link Vetoed} annotation.
+     *
+     * @author Martin Kouba
+     * @since 2.0
+     * @see Instance
+     * @see Event
+     */
+    public static final class Literal extends AnnotationLiteral<Vetoed> implements Vetoed {
+
+        private static final long serialVersionUID = 1L;
+
+        public static final Literal INSTANCE = new Literal();
+
+    }
 
 }

--- a/api/src/main/java/javax/enterprise/inject/literal/InjectLiteral.java
+++ b/api/src/main/java/javax/enterprise/inject/literal/InjectLiteral.java
@@ -1,0 +1,34 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2008, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package javax.enterprise.inject.literal;
+
+import javax.enterprise.util.AnnotationLiteral;
+import javax.inject.Inject;
+
+/**
+ * Supports inline instantiation of the {@link Inject} annotation.
+ *
+ * @author Martin Kouba
+ * @since 2.0
+ */
+public final class InjectLiteral extends AnnotationLiteral<Inject> implements Inject {
+
+    public static final InjectLiteral INSTANCE = new InjectLiteral();
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/api/src/test/java/org/jboss/cdi/api/test/AnnotationLiteralTest.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/AnnotationLiteralTest.java
@@ -14,12 +14,17 @@ import javax.enterprise.inject.Alternative;
 import javax.enterprise.inject.Any;
 import javax.enterprise.inject.Default;
 import javax.enterprise.inject.New;
+import javax.enterprise.inject.Specializes;
+import javax.enterprise.inject.TransientReference;
 import javax.enterprise.inject.Typed;
+import javax.enterprise.inject.Vetoed;
+import javax.enterprise.inject.literal.InjectLiteral;
 import javax.enterprise.inject.literal.NamedLiteral;
 import javax.enterprise.inject.literal.QualifierLiteral;
 import javax.enterprise.inject.literal.SingletonLiteral;
 import javax.enterprise.util.AnnotationLiteral;
 import javax.enterprise.util.Nonbinding;
+import javax.inject.Inject;
 import javax.inject.Qualifier;
 import javax.inject.Singleton;
 
@@ -153,6 +158,34 @@ public class AnnotationLiteralTest {
     public void testDependentLiteral() {
         assertEquals(new AnnotationLiteral<Dependent>() {
         }, Dependent.Literal.INSTANCE);
+    }
+    
+    @SuppressWarnings("serial")
+    @Test
+    public void testVetoedLiteral() {
+        assertEquals(new AnnotationLiteral<Vetoed>() {
+        }, Vetoed.Literal.INSTANCE);
+    }
+    
+    @SuppressWarnings("serial")
+    @Test
+    public void testInjectLiteral() {
+        assertEquals(new AnnotationLiteral<Inject>() {
+        }, InjectLiteral.INSTANCE);
+    }
+    
+    @SuppressWarnings("serial")
+    @Test
+    public void testSpecializesLiteral() {
+        assertEquals(new AnnotationLiteral<Specializes>() {
+        }, Specializes.Literal.INSTANCE);
+    }
+    
+    @SuppressWarnings("serial")
+    @Test
+    public void testTransientReferenceLiteral() {
+        assertEquals(new AnnotationLiteral<TransientReference>() {
+        }, TransientReference.Literal.INSTANCE);
     }
 
 }

--- a/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
@@ -40,7 +40,7 @@ Contexts and Dependency Injection 1.0 allowed only for an alternative to be sele
 
 [[declaring_selected_alternatives_application]]
 
-===== Declaring selected alternatives for an application 
+===== Declaring selected alternatives for an application
 
 An alternative may be given a priority for the application:
 
@@ -530,7 +530,7 @@ The log category of a `Logger` depends upon the class of the object into which i
 [source, java]
 ----
 @Produces Logger createLogger(InjectionPoint injectionPoint) {
-    return Logger.getLogger( injectionPoint.getMember().getDeclaringClass().getName() );    
+    return Logger.getLogger( injectionPoint.getMember().getDeclaringClass().getName() );
 }
 ----
 
@@ -585,13 +585,13 @@ Otherwise, the container automatically detects the problem and treats it as a de
 [source, java]
 ----
 @Named("Order") public class OrderProcessor {
-    
+
     @Inject Bean<OrderProcessor> bean;
-    
+
     public void getBeanName() {
        return bean.getName();
     }
-    
+
 }
 ----
 
@@ -667,16 +667,16 @@ The `Instance` interface provides a method for obtaining instances of beans with
 [source, java]
 ----
 public interface Instance<T> extends Iterable<T>, Provider<T> {
-      
+
     public Instance<T> select(Annotation... qualifiers);
     public <U extends T> Instance<U> select(Class<U> subtype, Annotation... qualifiers);
     public <U extends T> Instance<U> select(TypeLiteral<U> subtype, Annotation... qualifiers);
-    
+
     public boolean isUnsatisfied();
     public boolean isAmbiguous();
 
     public void destroy(T instance);
-      
+
 }
 ----
 
@@ -700,7 +700,7 @@ For example, this child `Instance` has required type `AsynchronousPaymentProcess
 
 [source, java]
 ----
-Instance<AsynchronousPaymentProcessor> async = anyPaymentProcessor.select( 
+Instance<AsynchronousPaymentProcessor> async = anyPaymentProcessor.select(
             AsynchronousPaymentProcessor.class, new AsynchronousQualifier() );
 ----
 
@@ -756,15 +756,15 @@ The built-in implementation must be a passivation capable dependency, as defined
 [source, java]
 ----
 public PaymentProcessor getSynchronousPaymentProcessor(PaymentMethod paymentMethod) {
-    
+
     class SynchronousQualifier extends AnnotationLiteral<Synchronous>
             implements Synchronous {}
-    
+
     class PayByQualifier extends AnnotationLiteral<PayBy>
             implements PayBy {
         public PaymentMethod value() { return paymentMethod; }
     }
-    
+
     return anyPaymentProcessor.select(new SynchronousQualifier(), new PayByQualifier()).get();
 }
 ----
@@ -781,11 +781,13 @@ public PaymentProcessor<Cheque> getChequePaymentProcessor() {
 
 ==== Built-in annotation literals
 
-As an helper, CDI 2.0 introduced built-in Literals for the following cdi annotations:
+The following built-in annotations define a `Literal` static nested class to support inline instantiation of the specific annotation type:
 
 * `javax.enterprise.inject.Any`
 * `javax.enterprise.inject.Default`
 * `javax.enterprise.inject.New`
+* `javax.enterprise.inject.Specializes`
+* `javax.enterprise.inject.Vetoed`
 * `javax.enterprise.util.Nonbinding`
 * `javax.enterprise.context.Initialized`
 * `javax.enterprise.context.Destroyed`
@@ -797,35 +799,36 @@ As an helper, CDI 2.0 introduced built-in Literals for the following cdi annotat
 * `javax.enterprise.inject.Alternative`
 * `javax.enterprise.inject.Typed`
 
-Each of these annotations contains a `Literal` inner class to instantiate the matching annotation literal:
+The `Literal` class might be used to instantiate the matching `AnnotationLiteral`:
 
 [source, java]
 ----
 Default defaultLiteral = new Default.Literal();
 ----
 
-Annotation without members can provide annotation literal instance from the `INSTANCE` static field:
+Annotations without members provide the default `AnnotationLiteral` instance declared as a constant named `INSTANCE`:
 
 [source, java]
 ----
 RequestScoped requestScopedLiteral = RequestScoped.Literal.INSTANCE;
 ----
 
-Annotation having members can provide annotation literal instance either from constructor or `of` static method:
+Annotations having members do not provide the default `AnnotationLiteral` instance. Instead, a constructor or factory method named `of` can be used:
 
 [source, java]
 ----
 Initialized initializedForApplicationScoped = new Initialized.Literal(ApplicationScoped.class);
 
-Initialized initializedForRequestScoped = Initialized.Instance.of(RequestScoped.class);
+Initialized initializedForRequestScoped = Initialized.Literal.of(RequestScoped.class);
 ----
 
-See annotation javadoc for information about `Literal` inner class constructor parameters.
+See also the annotation javadoc for more information about specific `Literal` members.
 
-In addition to these literals, CDI also provides annotation literals for the following JSR 330 annotations:
+In addition, CDI also provides annotation literals for the following JSR 330 annotations:
 
+* `javax.inject.Inject` with `javax.enterprise.inject.literal.InjectLiteral` class
 * `javax.inject.Named` with `javax.enterprise.inject.literal.NamedLiteral` class
 * `javax.inject.Qualifier` with `javax.enterprise.inject.literal.QualifierLiteral` class
 * `javax.inject.Singleton` with `javax.enterprise.inject.literal.SingletonLiteral` class
 
-They can be used like inner classes described above.
+They can be used like static nested classes described above.


### PR DESCRIPTION
- Inject, Vetoed, Specializes, TransientReference
- also polish the spec wording