### PR TITLE
CDI-596 ProcessAnnotatedType - clarify what happens if both setAnnotatedType() and configurator are used within observer notification

### DIFF
--- a/api/src/main/java/javax/enterprise/inject/spi/ProcessAnnotatedType.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ProcessAnnotatedType.java
@@ -24,9 +24,9 @@ import javax.enterprise.inject.spi.builder.AnnotatedTypeConfigurator;
  * the declared annotations.
  * </p>
  * <p>
- * Any observer of this event is permitted to wrap and/or replace the {@link javax.enterprise.inject.spi.AnnotatedType}. The
- * container must use the final value of this property, after all observers have been called, to discover the types and read the
- * annotations of the program elements.
+ * Any observer of this event is permitted to wrap and/or replace the {@link javax.enterprise.inject.spi.AnnotatedType} by calling either {@link #setAnnotatedType(AnnotatedType)} or {@link #configureAnnotatedType()}.
+ * If both methods are called in the observer method, an {@link IllegalStateException} is thrown.
+ * The container must use the final value of this property, after all observers have been called, to discover the types and read the annotations of the program elements.
  * </p>
  * <p>
  * For example, the following observer decorates the {@link javax.enterprise.inject.spi.AnnotatedType} for every class that is

--- a/api/src/main/java/javax/enterprise/inject/spi/ProcessAnnotatedType.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ProcessAnnotatedType.java
@@ -25,7 +25,7 @@ import javax.enterprise.inject.spi.builder.AnnotatedTypeConfigurator;
  * </p>
  * <p>
  * Any observer of this event is permitted to wrap and/or replace the {@link javax.enterprise.inject.spi.AnnotatedType} by calling either {@link #setAnnotatedType(AnnotatedType)} or {@link #configureAnnotatedType()}.
- * If both methods are called in the observer method, an {@link IllegalStateException} is thrown.
+ * If both methods are called within an observer notification an {@link IllegalStateException} is thrown.
  * The container must use the final value of this property, after all observers have been called, to discover the types and read the annotations of the program elements.
  * </p>
  * <p>

--- a/api/src/main/java/javax/enterprise/inject/spi/ProcessBeanAttributes.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ProcessBeanAttributes.java
@@ -29,6 +29,11 @@ import javax.enterprise.inject.spi.builder.BeanAttributesConfigurator;
  * No event is fired for {@link New} qualified beans.
  * </p>
  * <p>
+ * Any observer of this event is permitted to wrap and/or replace the {@link BeanAttributes} by calling either {@link #setBeanAttributes(BeanAttributes)} or {@link #configureBeanAttributes()}.
+ * If both methods are called within an observer notification an {@link IllegalStateException} is thrown.
+ * The container must use the final value of this property, after all observers have been called, to manage instances of the bean.
+ * </p>
+ * <p>
  * If any observer method of a {@code ProcessBeanAttributes} event throws an exception, the exception is treated as a definition
  * error by the container.
  * </p>

--- a/api/src/main/java/javax/enterprise/inject/spi/ProcessInjectionPoint.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ProcessInjectionPoint.java
@@ -27,8 +27,9 @@ import javax.enterprise.inject.spi.builder.InjectionPointConfigurator;
  * decorator.
  * </p>
  * <p>
- * Any observer of this event is permitted to wrap and/or replace the {@link javax.enterprise.inject.spi.InjectionPoint}. The
- * container must use the final value of this property, after all observers have been called, he container must use the final
+ * Any observer of this event is permitted to wrap and/or replace the {@link javax.enterprise.inject.spi.InjectionPoint} by calling either {@link #setInjectionPoint(InjectionPoint)} or {@link #configureInjectionPoint()}.
+ * If both methods are called within an observer notification an {@link IllegalStateException} is thrown.
+ * The container must use the final value of this property, after all observers have been called, he container must use the final
  * value of this property, after all observers have been called, whenever it performs injection upon the injection point.
  * </p>
  * <p>

--- a/api/src/main/java/javax/enterprise/inject/spi/ProcessObserverMethod.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ProcessObserverMethod.java
@@ -25,22 +25,28 @@ import javax.enterprise.inject.spi.builder.ObserverMethodConfigurator;
  * enabled bean, before registering the {@link javax.enterprise.inject.spi.ObserverMethod} object.
  * </p>
  * <p>
+ * Any observer of this event is permitted to wrap and/or replace the {@link javax.enterprise.inject.spi.ObserverMethod} by calling either {@link #setObserverMethod(ObserverMethod)} or {@link #configureObserverMethod()}.
+ * If both methods are called within an observer notification an {@link IllegalStateException} is thrown.
+ * The container must use the final value of this property, after all observers have been called, he container must use the final
+ * value of this property, after all observers have been called, whenever it performs observer resolution.
+ * </p>
+ * <p>
  * If any observer method of a {@code ProcessObserverMethod} event throws an exception, the exception is treated as a definition
  * error by the container.
  * </p>
- * 
+ *
  * @see ObserverMethod
  * @author Gavin King
  * @author David Allen
  * @author  Antoine Sabot-Durand
  * @param <T> The type of the event being observed
  * @param <X> The bean type containing the observer method
- * 
+ *
  */
 public interface ProcessObserverMethod<T, X> {
     /**
      * The {@link javax.enterprise.inject.spi.AnnotatedMethod} representing the observer method.
-     * 
+     *
      * @return the {@link javax.enterprise.inject.spi.AnnotatedMethod} representing the observer method
      * @throws IllegalStateException if called outside of the observer method invocation
      */
@@ -49,7 +55,7 @@ public interface ProcessObserverMethod<T, X> {
     /**
      * The {@link javax.enterprise.inject.spi.ObserverMethod} object that will be used by the container to invoke the observer
      * when a matching event is fired.
-     * 
+     *
      * @return the {@link javax.enterprise.inject.spi.ObserverMethod} object that will be used by the container to call the
      *         observer method
      * @throws IllegalStateException if called outside of the observer method invocation

--- a/spec/src/main/asciidoc/core/spi.asciidoc
+++ b/spec/src/main/asciidoc/core/spi.asciidoc
@@ -1300,7 +1300,9 @@ The method always return the same `InjectionPointConfigurator`.
 * `addDefinitionError()` registers a definition error with the container, causing the container to abort deployment after bean discovery is complete.
 
 
-Any observer of this event is permitted to wrap and/or replace the `InjectionPoint`. The container must use the final value of this property, after all observers have been called, whenever it performs injection upon the injection point.
+Any observer of this event is permitted to wrap and/or replace the `InjectionPoint` by calling either `setInjectionPoint()` or `configureInjectionPoint()`.
+If both methods are called within an observer notification an `IllegalStateException` is thrown.
+The container must use the final value of this property, after all observers have been called, whenever it performs injection upon the injection point.
 
 If any observer method of a `ProcessInjectionPoint` event throws an exception, the exception is treated as a definition error by the container.
 
@@ -1392,7 +1394,9 @@ The method always return the same `BeanAttributesConfigurator`.
 * `veto()` forces the container to ignore the bean.
 
 
-Any observer of this event is permitted to wrap and/or replace the `BeanAttributes`. The container must use the final value of this property, after all observers have been called, to manage instances of the bean.
+Any observer of this event is permitted to wrap and/or replace the `BeanAttributes` by calling either `setBeanAttributes()` or `configureBeanAttributes()`.
+If both methods are called within an observer notification an `IllegalStateException` is thrown.
+The container must use the final value of this property, after all observers have been called, to manage instances of the bean.
 Changes to `BeanAttributes` are _not_ propagated to the annotated type from which the bean definition was created.
 
 Any bean which has its bean attributes altered must have it's definition validated during deployment validation.
@@ -1551,6 +1555,9 @@ public interface ProcessObserverMethod<T, X> {
 The method always return the same `ObserverMethodConfigurator`.
 * `veto()` forces the container to ignore the `ObserverMethod`.
 
+Any observer of this event is permitted to wrap and/or replace the `ObserverMethod` by calling either `setObserverMethod()` or `configureObserverMethod()`.
+If both methods are called within an observer notification an `IllegalStateException` is thrown.
+The container must use the final value of this property, after all observers have been called, whenever it performs observer resolution.
 
 
 If any observer method of a `ProcessObserverMethod` event throws an exception, the exception is treated as a definition error by the container.

--- a/spec/src/main/asciidoc/core/spi.asciidoc
+++ b/spec/src/main/asciidoc/core/spi.asciidoc
@@ -1258,8 +1258,8 @@ The method always return the same `AnnotatedTypeConfigurator`
 * `getSource()` returns the `Extension` instance that added the annotated type.
 
 
-Any observer of this event is permitted to wrap and/or replace the `AnnotatedType` with either `setAnnotatedType()` or `configureAnnotatedType()` methods.
-If both methods are called in the observer method, an `IllegalStateException` is thrown.
+Any observer of this event is permitted to wrap and/or replace the `AnnotatedType` by calling either `setAnnotatedType()` or `configureAnnotatedType()`.
+If both methods are called within an observer notification an `IllegalStateException` is thrown.
 The container must use the final value of this property, after all observers have been called, as the only source of types and annotations for the program elements.
 
 For example, the following observer decorates the `AnnotatedType` for every class that is discovered by the container.

--- a/spec/src/main/asciidoc/core/spi.asciidoc
+++ b/spec/src/main/asciidoc/core/spi.asciidoc
@@ -1258,7 +1258,9 @@ The method always return the same `AnnotatedTypeConfigurator`
 * `getSource()` returns the `Extension` instance that added the annotated type.
 
 
-Any observer of this event is permitted to wrap and/or replace the `AnnotatedType`. The container must use the final value of this property, after all observers have been called, as the only source of types and annotations for the program elements.
+Any observer of this event is permitted to wrap and/or replace the `AnnotatedType` with either `setAnnotatedType()` or `configureAnnotatedType()` methods.
+If both methods are called in the observer method, an `IllegalStateException` is thrown.
+The container must use the final value of this property, after all observers have been called, as the only source of types and annotations for the program elements.
 
 For example, the following observer decorates the `AnnotatedType` for every class that is discovered by the container.
 


### PR DESCRIPTION
An IllegalStateException is thrown