### PR TITLE
CDI-625 Make it clear when exactly are context init/destroy events fired

### DIFF
--- a/api/src/main/java/javax/enterprise/context/BeforeDestroyed.java
+++ b/api/src/main/java/javax/enterprise/context/BeforeDestroyed.java
@@ -1,6 +1,6 @@
 /*
  * JBoss, Home of Professional Open Source
- * Copyright 2013, Red Hat, Inc., and individual contributors
+ * Copyright 2016, Red Hat, Inc., and individual contributors
  * by the @authors tag. See the copyright.txt in the distribution for a
  * full listing of individual contributors.
  *
@@ -32,31 +32,30 @@ import javax.enterprise.util.AnnotationLiteral;
 import javax.inject.Qualifier;
 
 /**
- * An event with this qualifier is fired when a context is intialized, i.e. ready for use. 
+ * An event with this qualifier is fired when a context is about to be destroyed, i.e. before the actual destruction. 
  *
  * @author Pete Muir
- * @see BeforeDestroyed
+ * @author Martin Kouba
+ * @see Initialized
  * @see Destroyed
- * @since 1.1
+ * @since 2.0
  */
 @Qualifier
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
 @Retention(RUNTIME)
 @Documented
-public @interface Initialized {
+public @interface BeforeDestroyed {
 
     /**
-     * The scope for which to observe initialization
+     * The scope for which to observe destruction
      */
     Class<? extends Annotation> value();
 
     /**
-     * Supports inline instantiation of the {@link Initialized} qualifier.
-     *
-     * @author Martin Kouba
+     * Supports inline instantiation of the {@link BeforeDestroyed} qualifier.
      */
-    public final static class Literal extends AnnotationLiteral<Initialized> implements Initialized {
-        
+    public final static class Literal extends AnnotationLiteral<BeforeDestroyed> implements BeforeDestroyed {
+
         public static final Literal REQUEST = of(RequestScoped.class); 
         
         public static final Literal CONVERSATION = of(ConversationScoped.class);
@@ -64,7 +63,7 @@ public @interface Initialized {
         public static final Literal SESSION = of(SessionScoped.class);
         
         public static final Literal APPLICATION = of(ApplicationScoped.class);
-
+        
         private static final long serialVersionUID = 1L;
 
         private final Class<? extends Annotation> value;

--- a/api/src/main/java/javax/enterprise/context/Destroyed.java
+++ b/api/src/main/java/javax/enterprise/context/Destroyed.java
@@ -32,14 +32,12 @@ import javax.enterprise.util.AnnotationLiteral;
 import javax.inject.Qualifier;
 
 /**
- * <p>
- * The <code>@Destroyed</code> qualifier.
- * </p>
+ * An event with this qualifier is fired when a context is destroyed, i.e. after the actual destruction.
  *
  * @author Pete Muir
  * @see Initialized
+ * @see BeforeDestroyed
  * @since 1.1
- *
  */
 @Qualifier
 @Target({ TYPE, METHOD, PARAMETER, FIELD })
@@ -58,6 +56,14 @@ public @interface Destroyed {
      * @author Martin Kouba
      */
     public final static class Literal extends AnnotationLiteral<Destroyed> implements Destroyed {
+
+        public static final Literal REQUEST = of(RequestScoped.class);
+
+        public static final Literal CONVERSATION = of(ConversationScoped.class);
+
+        public static final Literal SESSION = of(SessionScoped.class);
+
+        public static final Literal APPLICATION = of(ApplicationScoped.class);
 
         private static final long serialVersionUID = 1L;
 

--- a/api/src/test/java/org/jboss/cdi/api/test/AnnotationLiteralTest.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/AnnotationLiteralTest.java
@@ -4,6 +4,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.context.BeforeDestroyed;
 import javax.enterprise.context.ConversationScoped;
 import javax.enterprise.context.Dependent;
 import javax.enterprise.context.Destroyed;
@@ -118,13 +119,26 @@ public class AnnotationLiteralTest {
     @Test
     public void testInitializedLiteral() {
         assertEquals(Initialized.Literal.of(RequestScoped.class).value(), RequestScoped.class);
+        assertEquals(Initialized.Literal.REQUEST.value(), RequestScoped.class);
+        assertEquals(Initialized.Literal.CONVERSATION.value(), ConversationScoped.class);
+        assertEquals(Initialized.Literal.SESSION.value(), SessionScoped.class);
+        assertEquals(Initialized.Literal.APPLICATION.value(), ApplicationScoped.class);
     }
 
     @Test
     public void testDestroyedLiteral() {
         assertEquals(Destroyed.Literal.of(ConversationScoped.class).value(), ConversationScoped.class);
     }
-
+    
+    @Test
+    public void testBeforeDestroyedLiteral() {
+        assertEquals(BeforeDestroyed.Literal.of(RequestScoped.class).value(), RequestScoped.class);
+        assertEquals(BeforeDestroyed.Literal.REQUEST.value(), RequestScoped.class);
+        assertEquals(BeforeDestroyed.Literal.CONVERSATION.value(), ConversationScoped.class);
+        assertEquals(BeforeDestroyed.Literal.SESSION.value(), SessionScoped.class);
+        assertEquals(BeforeDestroyed.Literal.APPLICATION.value(), ApplicationScoped.class);
+    }
+    
     @SuppressWarnings("serial")
     @Test
     public void testApplicationScopedLiteral() {

--- a/spec/src/main/asciidoc/core/scopescontexts.asciidoc
+++ b/spec/src/main/asciidoc/core/scopescontexts.asciidoc
@@ -438,7 +438,14 @@ For example, a remoting framework might provide a request context object for the
 The context associated with a built-in normal scope propagates across local, synchronous Java method calls.
 The context does not propagate across remote method invocations or to asynchronous processes.
 
-Portable extensions are encouraged to synchronously fire an event with qualifier `@Initialized(X.class)` when a custom context is initialized, and an event with qualifier `@Destroyed(X.class)` when a custom context is destroyed, where X is the scope type associated with the context.
+Portable extensions are encouraged to synchronously fire:
+
+* an event with qualifier `@Initialized(X.class)` when a custom context is initialized, i.e. ready for use,
+* an event with qualifier `@BeforeDestroyed(X.class)` when a custom context is about to be destroyed, i.e. before the actual destruction,
+* an event with qualifier `@Destroyed(X.class)` when a custom context is destroyed, i.e. after the actual destruction,
+
+where `X` is the scope type associated with the context.
+
 A suitable event payload should be chosen.
 
 [[request_context]]
@@ -447,8 +454,9 @@ A suitable event payload should be chosen.
 
 The _request context_ is provided by a built-in context object for the built-in scope type `@RequestScoped`.
 
-An event with qualifier @Initialized(RequestScoped.class) is synchronously fired when the request context is initialized and an event with qualifier @Destroyed(RequestScoped.class) when the request context is destroyed.
-
+An event with qualifier `@Initialized(RequestScoped.class)` is synchronously fired when the request context is initialized.
+An event with qualifier `@BeforeDestroyed(RequestScoped.class)` is synchronously fired when the request context is about to be destroyed, i.e. before the actual destruction.
+An event with qualifier `@Destroyed(RequestScoped.class)` is synchronously fired when the request context is destroyed, i.e. after the actual destruction.
 
 [[session_context]]
 
@@ -462,8 +470,9 @@ The _session context_ is provided by a built-in context object for the built-in 
 
 The _application context_ is provided by a built-in context object for the built-in scope type `@ApplicationScoped`.
 
-An event with qualifier @Initialized(ApplicationScoped.class) is synchronously fired when the application context is initialized and an event with qualifier @Destroyed(ApplicationScoped.class) is synchronously fired when the application is destroyed.
-
+An event with qualifier `@Initialized(ApplicationScoped.class)` is synchronously fired when the application context is initialized.
+An event with qualifier `@BeforeDestroyed(ApplicationScoped.class)` is synchronously fired when the application context is about to be destroyed, i.e. before the actual destruction.
+An event with qualifier `@Destroyed(ApplicationScoped.class)` is synchronously fired when the application context is destroyed, i.e. after the actual destruction.
 
 [[conversation_context]]
 

--- a/spec/src/main/asciidoc/javaee/scopescontext_ee.asciidoc
+++ b/spec/src/main/asciidoc/javaee/scopescontext_ee.asciidoc
@@ -117,11 +117,13 @@ The session scope is active:
 
 * during the `service()` method of any servlet in the web application, during the `doFilter()` method of any servlet filter and when the container calls any `HttpSessionListener`, `AsyncListener` or `ServletRequestListener`.
 
-
 The session context is shared between all servlet requests that occur in the same HTTP session.
 The session context is destroyed when the `HTTPSession` times out, after all `HttpSessionListener` s have been called, and at the very end of any request in which `invalidate()` was called, after all filters and `ServletRequestListener` s have been called.
 
-An event with the `HttpSession` as payload and with qualifier `@Initialized(SessionScoped.class)` is fired when the session context is initialized and an event with qualifier `@Destroyed(SessionScoped.class)` when the session context is destroyed.
+An event with qualifier `@Initialized(SessionScoped.class)` is synchronously fired when the session context is initialized.
+An event with qualifier `@BeforeDestroyed(SessionScoped.class)` is synchronously fired when the session context is about to be destroyed, i.e. before the actual destruction.
+An event with qualifier `@Destroyed(SessionScoped.class)` is synchronously fired when the session context is destroyed, i.e. after the actual destruction.
+The event payload is `javax.servlet.http.HttpSession`.
 
 [[application_context_ee]]
 
@@ -156,7 +158,9 @@ When running in Java EE the container is required to implement conversation cont
 
 The conversation scope is active during all Servlet requests.
 
-An event with qualifier `@Initialized(ConversationScoped.class)` is fired when the conversation context is initialized and an event with qualifier `@Destroyed(ConversationScoped.class)` is fired when the conversation is destroyed.
+An event with qualifier `@Initialized(ConversationScoped.class)` is synchronously fired when the conversation context is initialized.
+An event with qualifier `@BeforeDestroyed(ConversationScoped.class)` is synchronously fired when the conversation is about to be destroyed, i.e. before the actual destruction.
+An event with qualifier `@Destroyed(ConversationScoped.class)` is synchronously fired when the conversation is destroyed, i.e. after the actual destruction.
 The event payload is:
 
 * the conversation id if the conversation context is destroyed and is not associated with a current Servlet request, or


### PR DESCRIPTION
- add @BeforeDestroyed and @AfterDestroyed
- deprecate @Destroyed
