### PR TITLE
CDI-634 clarify contextual ref. validity.

### DIFF
--- a/spec/src/main/asciidoc/core/scopescontexts.asciidoc
+++ b/spec/src/main/asciidoc/core/scopescontexts.asciidoc
@@ -283,6 +283,7 @@ The validity of a contextual reference for a bean depends upon whether the scope
 
 * Any reference to a bean with a normal scope is valid as long as the application maintains a hard reference to it.
 However, it may only be invoked when the context associated with the normal scope is active. If it is invoked when the context is inactive, a `ContextNotActiveException` is thrown by the container.
+* Any reference to a bean with a normal scope is invalid after CDI container shutdown. Maintaining such reference and attempting to use it after container shutdown results in an `IllegalStateException`.
 * Any reference to a bean with a pseudo-scope (such as `@Dependent`) is valid until the bean instance to which it refers is destroyed.
 It may be invoked even if the context associated with the pseudo-scope is not active. If the application invokes a method of a reference to an instance that has already been destroyed, the behavior is undefined.
 


### PR DESCRIPTION
A proposed clarification for CDI-634.

I am not sure if we should place this in section `6.5.4. Contextual reference validity` (as proposed here) since it is generally valid for both, EE and SE. Or if it should go into SE part of the doc.

Feel free to suggest && comment.
