### PR TITLE
CDI-614 remove InjectionPointConfigurator read methods.

### DIFF
--- a/api/src/main/java/javax/enterprise/inject/spi/configurator/InjectionPointConfigurator.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/configurator/InjectionPointConfigurator.java
@@ -17,19 +17,15 @@
 
 package javax.enterprise.inject.spi.configurator;
 
-import javax.enterprise.inject.spi.AnnotatedField;
-import javax.enterprise.inject.spi.AnnotatedParameter;
 import javax.enterprise.inject.spi.Bean;
 import javax.enterprise.inject.spi.InjectionPoint;
 import javax.enterprise.inject.spi.ProcessInjectionPoint;
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
-import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.Set;
 
 /**
- * This API is an helper to configure a new {@link InjectionPoint} instance.
+ * This API is an helper to configure an existing {@link InjectionPoint} instance.
  * CDI container must provides an implementation of this interface.
  *
  * This builder is not thread safe and shall not be used concurrently.
@@ -39,51 +35,6 @@ import java.util.Set;
  * @since 2.0
  */
 public interface InjectionPointConfigurator {
-
-    /**
-     * Read the InjectionPoint information from the given {@link Field}.
-     * All relevant information is overwritten.
-     *
-     * @param field defining the InjectionPoint.
-     * @return self
-     */
-    InjectionPointConfigurator read(Field field);
-
-    /**
-     * Read the InjectionPoint information from the given {@link Parameter}.
-     * All relevant information is overwritten.
-     *
-     * @param param  the parameter defining the InjectionPoint
-     * @return self
-     */
-    InjectionPointConfigurator read(Parameter param);
-
-    /**
-     * Read the InjectionPoint information from the given {@link AnnotatedField}.
-     * All relevant information is overwritten.
-     *
-     * @param field defining the InjectionPoint
-     * @return self
-     */
-    InjectionPointConfigurator read(AnnotatedField<?> field);
-
-    /**
-     * Read the InjectionPoint information from the given {@link AnnotatedParameter}.
-     * All relevant information is overwritten.
-     *
-     * @param param defining the InjectionPoint
-     * @return self
-     */
-    InjectionPointConfigurator read(AnnotatedParameter<?> param);
-
-    /**
-     * Read the InjectionPoint information from the given {@link InjectionPoint}.
-     * All relevant information is overwritten.
-     *
-     * @param injectionPoint the InjectionPoint to get information from
-     * @return self
-     */
-    InjectionPointConfigurator read(InjectionPoint injectionPoint);
 
     /**
      * Set the required {@link Type} (that will be used during typesafe resolution)

--- a/spec/src/main/asciidoc/core/spi.asciidoc
+++ b/spec/src/main/asciidoc/core/spi.asciidoc
@@ -1317,9 +1317,7 @@ If any `ProcessInjectionPoint` method is called outside of the observer method i
 
 ===== `InjectionPointConfigurator` interface
 
-CDI 2.0 introduced the `javax.enterprise.inject.spi.configurator.InjectionPointConfigurator` interface to help configure a new `InjectionPoint` instance.
-
-`InjectionPointConfigurator` must be initialized from a field, a method or constructor parameter or an existing `InjectionPoint` with one of its `read()` methods.
+CDI 2.0 introduced the `javax.enterprise.inject.spi.configurator.InjectionPointConfigurator` interface to help configure an existing `InjectionPoint` instance.
 
 With `InjectionPointConfigurator` you can perform the following operations:
 


### PR DESCRIPTION
I consider them completely useless. Please prove if I am wrong and demonstrate some nice use case when it could be useful. 
