### PR TITLE
CDI-636 Introduce the ability to stream bean instances, as well as parallel stream them.

### DIFF
--- a/api/src/main/java/javax/enterprise/inject/Instance.java
+++ b/api/src/main/java/javax/enterprise/inject/Instance.java
@@ -17,10 +17,11 @@
 
 package javax.enterprise.inject;
 
-import java.lang.annotation.Annotation;
-
 import javax.enterprise.util.TypeLiteral;
 import javax.inject.Provider;
+import java.lang.annotation.Annotation;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 /**
  * <p>
@@ -132,7 +133,7 @@ public interface Instance<T> extends Iterable<T>, Provider<T> {
      * @throws IllegalArgumentException if passed two instances of the same qualifier type, or an instance of an annotation that
      *         is not a qualifier type
      */
-    public Instance<T> select(Annotation... qualifiers);
+    Instance<T> select(Annotation... qualifiers);
 
     /**
      * <p>
@@ -146,7 +147,7 @@ public interface Instance<T> extends Iterable<T>, Provider<T> {
      * @throws IllegalArgumentException if passed two instances of the same qualifier type, or an instance of an annotation that
      *         is not a qualifier type
      */
-    public <U extends T> Instance<U> select(Class<U> subtype, Annotation... qualifiers);
+    <U extends T> Instance<U> select(Class<U> subtype, Annotation... qualifiers);
 
     /**
      * <p>
@@ -160,7 +161,19 @@ public interface Instance<T> extends Iterable<T>, Provider<T> {
      * @throws IllegalArgumentException if passed two instances of the same qualifier type, or an instance of an annotation that
      *         is not a qualifier type
      */
-    public <U extends T> Instance<U> select(TypeLiteral<U> subtype, Annotation... qualifiers);
+    <U extends T> Instance<U> select(TypeLiteral<U> subtype, Annotation... qualifiers);
+
+    /**
+     * <p>
+     * When called, provides back a Stream of the beans available in this Instance.  If no beans are found, it
+     * returns an empty stream.
+     * </p>
+     *
+     * @return a <tt>Stream</tt> representing the beans associated with this {@link Instance} object
+     */
+    default Stream<T> stream(){
+        return StreamSupport.stream(this.spliterator(), false);
+    }
 
     /**
      * <p>
@@ -171,7 +184,7 @@ public interface Instance<T> extends Iterable<T>, Provider<T> {
      * @return <tt>true</tt> if there is no bean that matches the required type and qualifiers and is eligible for injection
      *         into the class into which the parent <tt>Instance</tt> was injected, or <tt>false</tt> otherwise.
      */
-    public boolean isUnsatisfied();
+    boolean isUnsatisfied();
 
     /**
      * <p>
@@ -182,7 +195,7 @@ public interface Instance<T> extends Iterable<T>, Provider<T> {
      * @return <tt>true</tt> if there is more than one bean that matches the required type and qualifiers and is eligible for
      *         injection into the class into which the parent <tt>Instance</tt> was injected, or <tt>false</tt> otherwise.
      */
-    public boolean isAmbiguous();
+    boolean isAmbiguous();
 
     /**
      * <p>
@@ -202,6 +215,6 @@ public interface Instance<T> extends Iterable<T>, Provider<T> {
      * @throws UnsupportedOperationException if the active context object for the scope type of the bean does not support
      *         destroying bean instances
      */
-    public void destroy(T instance);
+    void destroy(T instance);
 
 }

--- a/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
@@ -668,14 +668,17 @@ The `Instance` interface provides a method for obtaining instances of beans with
 ----
 public interface Instance<T> extends Iterable<T>, Provider<T> {
 
-    public Instance<T> select(Annotation... qualifiers);
-    public <U extends T> Instance<U> select(Class<U> subtype, Annotation... qualifiers);
-    public <U extends T> Instance<U> select(TypeLiteral<U> subtype, Annotation... qualifiers);
+    Instance<T> select(Annotation... qualifiers);
+    <U extends T> Instance<U> select(Class<U> subtype, Annotation... qualifiers);
+    <U extends T> Instance<U> select(TypeLiteral<U> subtype, Annotation... qualifiers);
 
-    public boolean isUnsatisfied();
-    public boolean isAmbiguous();
+    Stream<T> stream();
 
-    public void destroy(T instance);
+    boolean isUnsatisfied();
+    boolean isAmbiguous();
+
+    void destroy(T instance);
+
 
 }
 ----
@@ -722,6 +725,10 @@ The `iterator()` method must:
 * Identify the set of beans that have the required type and required qualifiers and are eligible for injection into the class into which the parent `Instance` was injected, according to the rules of typesafe resolution, as defined in <<performing_typesafe_resolution>>, resolving ambiguities according to <<unsatisfied_and_ambig_dependencies>>.
 * Return an `Iterator`, that iterates over the set of contextual references for the resulting beans and required type, as defined in <<contextual_reference>>.
 
+The `stream()` method must:
+
+* Identify the set of beans that have the required type and required qualifiers and are eligible for injection into the class into which the parent `Instance` was injected, according to the rules of typesafe resolution, as defined in <<performing_typesafe_resolution>>, resolving ambiguities according to <<unsatisfied_and_ambig_dependencies>>.
+* Returns a `Stream`, that can stream over the set of contextual references for the resulting beans and required type, as defined in <<contextual_reference>>.
 
 The method `isUnsatisfied()` returns `true` if there is no bean that has the required type and qualifiers and is eligible for injection into the class into which the parent `Instance` was injected, or `false` otherwise.
 


### PR DESCRIPTION
Introduces `stream()` and `parallelStream()` methods for bean instances.
