### PR TITLE
CDI-627 also re-enable the rules of CDI-1.0

### DIFF
--- a/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
@@ -74,7 +74,12 @@ An alternative is selected for the bean archive if either:
 ----
 
 Each child `<class>` element must specify the name of a bean class of an alternative bean.
-If there is no bean whose bean class has the specified name, or if no bean whose bean class has the specified name is an alternative, the container automatically detects the problem and treats it as a deployment problem.
+For each of them the container verifies that either:
+
+* a class T exists which is annotated with `@Alternative` or contains a producer field or producer method which is annotated with `@Alternative`, or
+* an alternative `Bean<T>` exists for the bean class.
+
+Otherwise the container automatically detects the problem and treats it as a deployment problem.
 
 Each child `<stereotype>` element must specify the name of an `@Alternative` stereotype annotation.
 If there is no annotation with the specified name, or the annotation is not an `@Alternative` stereotype, the container automatically detects the problem and treats it as a deployment problem.

--- a/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
@@ -75,7 +75,7 @@ An alternative is selected for the bean archive if either:
 
 For each child `<class>` element the container verifies that either:
 
-* a class T exists which is annotated with `@Alternative` or contains a producer field or producer method which is annotated with `@Alternative`, or
+* a class `T` exists which is annotated with `@Alternative` or contains a producer field or producer method which is annotated with `@Alternative`, or
 * an alternative `Bean<T>` exists for the bean class.
 
 Otherwise the container automatically detects the problem and treats it as a deployment problem.

--- a/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
@@ -73,8 +73,7 @@ An alternative is selected for the bean archive if either:
 </beans>
 ----
 
-Each child `<class>` element must specify the name of a bean class of an alternative bean.
-For each of them the container verifies that either:
+For each child `<class>` element the container verifies that either:
 
 * a class T exists which is annotated with `@Alternative` or contains a producer field or producer method which is annotated with `@Alternative`, or
 * an alternative `Bean<T>` exists for the bean class.


### PR DESCRIPTION
This is for fixing a backward-incompatible change we introduced in CDI-1.1.

The whole reason for verifying the <class> entries is to ensure that a user
doesn't have typos or list classes which do not exists or are no
'candidates' for being an Alternative at least.
So it's all about preventing user errors. Disallowing to veto() @Alternative
classes (which was perfectly allowed in CDI-1.0) was overreaching.