### PR TITLE
CDI-592 Add overloader ObserverMethod.notify()

### DIFF
--- a/api/src/main/java/javax/enterprise/inject/spi/EventContext.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/EventContext.java
@@ -1,0 +1,42 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016 Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package javax.enterprise.inject.spi;
+
+/**
+ * Represents a context of a fired event. Provides access to an event object and corresponding metadata.
+ * 
+ * @author Martin Kouba
+ * @see ObserverMethod#notify(EventContext)
+ * @see EventMetadata
+ * @since 2.0
+ */
+public interface EventContext<T> {
+
+    /**
+     * 
+     * @return the event object, aka the payload
+     */
+    T getEventObject();
+
+    /**
+     * 
+     * @return the event metadata
+     */
+    EventMetadata getMetadata();
+
+}

--- a/api/src/main/java/javax/enterprise/inject/spi/ObserverMethod.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ObserverMethod.java
@@ -30,6 +30,11 @@ import javax.enterprise.event.TransactionPhase;
  * bean}. Defines everything the container needs to know about an observer method.
  * </p>
  * 
+ * <p>
+ * If a custom implementation of this interface does not override either {@link #notify(Object)} or
+ * {@link #notify(EventContext)}, the container automatically detects the problem and treats it as a definition error.
+ * </p>
+ * 
  * @author Gavin King
  * @author David Allen
  * @author Mark Paluch
@@ -99,7 +104,22 @@ public interface ObserverMethod<T> extends Prioritized {
      * 
      * @param event the event object
      */
-    public void notify(T event);
+    public default void notify(T event) {
+    }
+    
+    /**
+     * Calls the observer method, passing the given event context.
+     * <p>
+     * The container should always call this method, but the default implementation delegates to {@link #notify(Object)}.
+     * <p>
+     * The implementation of this method for a custom observer method is responsible for deciding whether to call the method if
+     * the {@link #getReception()} returns {@link Reception#IF_EXISTS}.
+     * 
+     * @param eventContext
+     */
+    public default void notify(EventContext<T> eventContext) {
+        notify(eventContext.getEventObject());
+    }
 
     /**
      * <p>

--- a/spec/src/main/asciidoc/core/events.asciidoc
+++ b/spec/src/main/asciidoc/core/events.asciidoc
@@ -531,7 +531,7 @@ The `BeanManager.fireEvent()` or `Event.fire()` method rethrows the exception.
 If the exception is a checked exception, it is wrapped and rethrown as an (unchecked) `ObserverException`.
 
 
-For a custom implementation of the `ObserverMethod` interface defined in <<observer_method>>, the container must call `getTransactionPhase()` to determine if the observer method is transactional observer method, and `notify()` to invoke the method.
+For a custom implementation of the `ObserverMethod` interface defined in <<observer_method>>, the container must call `getTransactionPhase()` to determine if the observer method is transactional observer method, and `notify()` which accepts `javax.enterprise.inject.spi.EventContext` to invoke the method.
 
 [[async_exception]]
 

--- a/spec/src/main/asciidoc/core/spi.asciidoc
+++ b/spec/src/main/asciidoc/core/spi.asciidoc
@@ -122,6 +122,7 @@ public interface ObserverMethod<T> {
     public TransactionPhase getTransactionPhase();
     public int getPriority();
     public void notify(T event);
+    public void notify(EventContext<T> eventContext);
     public boolean isAsync();
 }
 ----
@@ -1110,6 +1111,8 @@ The given `Bean` may implement `Interceptor` or `Decorator`.
 +
 The second version of the method, returns a new `BeanConfigurator` as defined in <<bean_configurator>> to easily configure the `Bean` which will be added at the end of observer invocation.
 * `addObserverMethod()` fires an event of type `ProcessObserverMethod` containing the given `ObserverMethod` and then registers the `ObserverMethod` with the container, thereby making it available for event notifications.
++
+If the given `ObserverMethod` does not override either `ObserverMethod.notify(T)` or `ObserverMethod.notify(EventContext<T>)`, the container automatically detects the problem and treats it as a definition error.
 +
 The second version of the method, returns a new `ObserverMethodConfigurator` as defined in <<observer_method_configurator>> to easily configure the `ObserverMethod` which will be added at the end of observer invocation.
 * `addContext()` registers a custom `Context` object with the container.


### PR DESCRIPTION
https://issues.jboss.org/browse/CDI-592

I'm not 100% sure this is the best solution but I haven't found anything better.

This PR also introduces a new interface: `EventContext` which represents a context of a fired event (payload and metadata). I like this concept more than adding just another method parameter because it's easily extensible.

NOTE: If we go this way (introduce `EventContext`) we may also simplify `ObserverMethodConfigurator` which currently contains two versions of `notifyWith()`.
