### PR TITLE
CDI-612 Introduce EventConsumer

### DIFF
--- a/api/src/main/java/javax/enterprise/inject/spi/EventContext.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/EventContext.java
@@ -31,7 +31,7 @@ public interface EventContext<T> {
      * 
      * @return the event object, aka the payload
      */
-    T getEventObject();
+    T getEvent();
 
     /**
      * 

--- a/api/src/main/java/javax/enterprise/inject/spi/ObserverMethod.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ObserverMethod.java
@@ -121,7 +121,7 @@ public interface ObserverMethod<T> extends Prioritized {
      * @param eventContext
      */
     public default void notify(EventContext<T> eventContext) {
-        notify(eventContext.getEventObject());
+        notify(eventContext.getEvent());
     }
 
     /**

--- a/api/src/main/java/javax/enterprise/inject/spi/configurator/ObserverMethodConfigurator.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/configurator/ObserverMethodConfigurator.java
@@ -29,15 +29,21 @@ import javax.enterprise.inject.spi.AfterBeanDiscovery;
 import javax.enterprise.inject.spi.AnnotatedMethod;
 import javax.enterprise.inject.spi.EventContext;
 import javax.enterprise.inject.spi.ObserverMethod;
+import javax.enterprise.inject.spi.ProcessObserverMethod;
 
 /**
- * This API is an helper to build a new {@link ObserverMethod} instance. CDI container must provides an implementation of this
- * interface accessible.
- *
+ * <p>
+ * An {@link ObserverMethodConfigurator} can configure an {@link ObserverMethod}. The container must provide an implementation
+ * of this interface.
+ * </p>
+ * 
+ * <p>
  * This configurator is not thread safe and shall not be used concurrently.
+ * </p>
  *
  * @param <T> type of the event the configured ObserverMethod will observe
  * @author Antoine Sabot-Durand
+ * @see ProcessObserverMethod#configureObserverMethod()
  * @see AfterBeanDiscovery#addObserverMethod()
  * @since 2.0
  */

--- a/api/src/main/java/javax/enterprise/inject/spi/configurator/ObserverMethodConfigurator.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/configurator/ObserverMethodConfigurator.java
@@ -17,22 +17,22 @@
 
 package javax.enterprise.inject.spi.configurator;
 
-import javax.enterprise.event.Reception;
-import javax.enterprise.event.TransactionPhase;
-import javax.enterprise.inject.spi.AfterBeanDiscovery;
-import javax.enterprise.inject.spi.AnnotatedMethod;
-import javax.enterprise.inject.spi.EventMetadata;
-import javax.enterprise.inject.spi.ObserverMethod;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.Set;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
+
+import javax.enterprise.event.ObserverException;
+import javax.enterprise.event.Reception;
+import javax.enterprise.event.TransactionPhase;
+import javax.enterprise.inject.spi.AfterBeanDiscovery;
+import javax.enterprise.inject.spi.AnnotatedMethod;
+import javax.enterprise.inject.spi.EventContext;
+import javax.enterprise.inject.spi.ObserverMethod;
 
 /**
- * This API is an helper to build a new {@link ObserverMethod} instance.
- * CDI container must provides an implementation of this interface accessible.
+ * This API is an helper to build a new {@link ObserverMethod} instance. CDI container must provides an implementation of this
+ * interface accessible.
  *
  * This configurator is not thread safe and shall not be used concurrently.
  *
@@ -68,8 +68,7 @@ public interface ObserverMethodConfigurator<T> {
     ObserverMethodConfigurator<T> read(ObserverMethod<T> method);
 
     /**
-     * Set the class of the Bean containing this observer.
-     * If not set, the extension class is used.
+     * Set the class of the Bean containing this observer. If not set, the extension class is used.
      *
      * @param type the bean class containing this configurator.
      * @return self
@@ -149,20 +148,12 @@ public interface ObserverMethodConfigurator<T> {
     ObserverMethodConfigurator<T> priority(int priority);
 
     /**
-     * Define Consumer to call when event is notified
+     * Define an operation that accepts a context of a fired event.
      *
      * @param callback to call for the event notification
      * @return self
      */
-    ObserverMethodConfigurator<T> notifyWith(Consumer<T> callback);
-
-    /**
-     * Defines a BiConsumer to call when event is notified
-     *
-     * @param callback a BiConsumer taking an event type and an EventMetadata as type parameters
-     * @return self
-     */
-    ObserverMethodConfigurator<T> notifyWith(BiConsumer<T, EventMetadata> callback);
+    ObserverMethodConfigurator<T> notifyWith(EventConsumer<T> callback);
 
     /**
      * Allows modification of the asynchronous status of the observer to build.
@@ -171,4 +162,24 @@ public interface ObserverMethodConfigurator<T> {
      * @return self
      */
     ObserverMethodConfigurator<T> async(boolean async);
+
+    /**
+     * Represents an operation that accepts a context of a fired event.
+     * 
+     * @author Martin Kouba
+     *
+     * @param <T>
+     * @see EventContext
+     */
+    @FunctionalInterface
+    interface EventConsumer<T> {
+
+        /**
+         * 
+         * @param eventContext
+         * @throws Exception The thrown checked exception is wrapped and rethrown as an (unchecked) {@link ObserverException}
+         */
+        void accept(EventContext<T> eventContext) throws Exception;
+
+    }
 }

--- a/spec/src/main/asciidoc/core/spi.asciidoc
+++ b/spec/src/main/asciidoc/core/spi.asciidoc
@@ -1172,10 +1172,11 @@ With `BeanConfigurator` you can perform all the operations defined in <<bean_att
 
 ===== `ObserverMethodConfigurator` interface
 
-CDI 2.0 introduced the `javax.enterprise.inject.spi.configurator.ObserverMethodConfigurator` interface to help configuring a new `ObserverMethod` instance.
+CDI 2.0 introduced the `javax.enterprise.inject.spi.configurator.ObserverMethodConfigurator` interface to help configuring an `ObserverMethod` instance.
 
 With `ObserverMethodConfigurator` you can perform the following operations:
 
+* Read the observer metadata from a `java.lang.reflect.Method`, `AnnotatedMethod` or an existing `ObserverMethod` with one of its `read()` methods.
 * Set the `ObserverMethod` bean class with `beanClass` method.
 * Set the type of the observed event with `observedType` method.
 * Add a qualifier with `addQualifier` method.

--- a/spec/src/main/asciidoc/core/spi.asciidoc
+++ b/spec/src/main/asciidoc/core/spi.asciidoc
@@ -1185,7 +1185,7 @@ With `ObserverMethodConfigurator` you can perform the following operations:
 * Set the `Reception` type with reception method.
 * Set the `TransactionPhase` type with `transactionPhase` method.
 * Set the priority with `priority` method.
-* Define the `Consumer` to call on notification with `notifyWith` method.
+* Define the `EventConsumer` to call on notification with `notifyWith` method.
 * Make the observer asynchronous with `async` method.
 
 [[after_deployment_validation]]

--- a/spec/src/main/asciidoc/core/spi.asciidoc
+++ b/spec/src/main/asciidoc/core/spi.asciidoc
@@ -1174,8 +1174,6 @@ With `BeanConfigurator` you can perform all the operations defined in <<bean_att
 
 CDI 2.0 introduced the `javax.enterprise.inject.spi.configurator.ObserverMethodConfigurator` interface to help configuring a new `ObserverMethod` instance.
 
-`ObserverMethodConfigurator` must be initialized from a `java.lang.reflect.Method`, `AnnotatedMethod` or an existing `ObserverMethod` with one of its `read()` methods.
-
 With `ObserverMethodConfigurator` you can perform the following operations:
 
 * Set the `ObserverMethod` bean class with `beanClass` method.


### PR DESCRIPTION
- accepts EventContext
- there is no need to define two notifyWith() methods anymore
- allows to throw checked exceptions within a callback