### PR TITLE
CDI-642 Allow defining interceptor binding or qualifier with an AnnotatedTypeConfigurator

### DIFF
--- a/api/src/main/java/javax/enterprise/inject/spi/BeforeBeanDiscovery.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/BeforeBeanDiscovery.java
@@ -202,4 +202,45 @@ public interface BeforeBeanDiscovery {
     public <T> AnnotatedTypeConfigurator<T> addAnnotatedType(Class<T> type, String id);
 
 
+    /**
+     *
+     * <p>
+     * Obtains a new {@link AnnotatedTypeConfigurator} to configure a new {@link javax.enterprise.inject.spi.AnnotatedType} and
+     * and declares it as a {@linkplain javax.inject.Qualifier} qualifier type.
+     * </p>
+     *
+     * <p>
+     * This is only required if you wish to make an annotation a qualifier without adding {@link Qualifier} to it and need to
+     * easily add other annotations (like {@link javax.enterprise.util.Nonbinding} on its members.
+     * </p>
+     *
+     * @param qualifier The annotation used to initialized the configurator
+     * @throws IllegalStateException if called outside of the observer method invocation
+     * @return a non reusable {@link AnnotatedTypeConfigurator} to configure the qualifier
+     * @since 2.0
+     */
+    public <X extends Annotation> AnnotatedTypeConfigurator<X> addConfiguredQualifier(AnnotatedType<X> qualifier);
+
+
+    /**
+     *
+     * <p>
+     * Obtains a new {@link AnnotatedTypeConfigurator} to configure a new {@link javax.enterprise.inject.spi.AnnotatedType} and
+     * and declares it as an {@linkplain Interceptor interceptor} binding type.
+     * </p>
+     *
+     * <p>
+     * This is only required if you wish to make an annotation an interceptor binding type without adding
+     * {@link InterceptorBinding} to it and need to easily add other annotations
+     * (like {@link javax.enterprise.util.Nonbinding} on its members.
+     * </p>
+     *
+     * @param bindingType The annotation used to initialized the configurator
+     * @throws IllegalStateException if called outside of the observer method invocation
+     * @return a non reusable {@link AnnotatedTypeConfigurator} to configure the interceptor binding
+     * @since 2.0
+     */
+    public <X extends Annotation> AnnotatedTypeConfigurator<X> addConfiguredInterceptorBinding(AnnotatedType<X> bindingType);
+
+
 }

--- a/api/src/main/java/javax/enterprise/inject/spi/BeforeBeanDiscovery.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/BeforeBeanDiscovery.java
@@ -205,7 +205,7 @@ public interface BeforeBeanDiscovery {
     /**
      *
      * <p>
-     * Obtains a new {@link AnnotatedTypeConfigurator} to configure a new {@link javax.enterprise.inject.spi.AnnotatedType} and
+     * Obtains a new {@link AnnotatedTypeConfigurator} to configure a new {@link javax.enterprise.inject.spi.AnnotatedType}
      * and declares it as a {@linkplain javax.inject.Qualifier} qualifier type.
      * </p>
      *
@@ -214,18 +214,18 @@ public interface BeforeBeanDiscovery {
      * easily add other annotations (like {@link javax.enterprise.util.Nonbinding} on its members.
      * </p>
      *
-     * @param qualifier The annotation used to initialized the configurator
+     * @param qualifier The annotation class used to initialized the configurator
      * @throws IllegalStateException if called outside of the observer method invocation
      * @return a non reusable {@link AnnotatedTypeConfigurator} to configure the qualifier
      * @since 2.0
      */
-    public <X extends Annotation> AnnotatedTypeConfigurator<X> addConfiguredQualifier(AnnotatedType<X> qualifier);
+     <T extends Annotation> AnnotatedTypeConfigurator<T> configureQualifier(Class<T> qualifier);
 
 
     /**
      *
      * <p>
-     * Obtains a new {@link AnnotatedTypeConfigurator} to configure a new {@link javax.enterprise.inject.spi.AnnotatedType} and
+     * Obtains a new {@link AnnotatedTypeConfigurator} to configure a new {@link javax.enterprise.inject.spi.AnnotatedType}
      * and declares it as an {@linkplain Interceptor interceptor} binding type.
      * </p>
      *
@@ -235,12 +235,12 @@ public interface BeforeBeanDiscovery {
      * (like {@link javax.enterprise.util.Nonbinding} on its members.
      * </p>
      *
-     * @param bindingType The annotation used to initialized the configurator
+     * @param bindingType The annotation class used to initialized the configurator
      * @throws IllegalStateException if called outside of the observer method invocation
      * @return a non reusable {@link AnnotatedTypeConfigurator} to configure the interceptor binding
      * @since 2.0
      */
-    public <X extends Annotation> AnnotatedTypeConfigurator<X> addConfiguredInterceptorBinding(AnnotatedType<X> bindingType);
+     <T extends Annotation> AnnotatedTypeConfigurator<T> configureInterceptorBinding(Class<T> bindingType);
 
 
 }

--- a/spec/src/main/asciidoc/core/spi.asciidoc
+++ b/spec/src/main/asciidoc/core/spi.asciidoc
@@ -1028,6 +1028,8 @@ public interface BeforeBeanDiscovery {
     public void addAnnotatedType(AnnotatedType<?> type);
     public void addAnnotatedType(AnnotatedType<?> type, String id);
     public AnnotatedTypeConfigurator<?> addAnnotatedType(Class<T> type,String id);
+    <T extends Annotation> AnnotatedTypeConfigurator<T> configureQualifier(Class<T> qualifier);
+    <T extends Annotation> AnnotatedTypeConfigurator<T> configureInterceptorBinding(Class<T> bindingType);
 }
 ----
 
@@ -1040,6 +1042,8 @@ The first version of the method is deprecated since version 1.1 of Contexts and 
 +
 The third version of the method, returns a new `AnnotatedTypeConfigurator` as defined in <<annotated_type_configurator>> to easily configure the `AnnotatedType` which will be added at the end of the observer invocation.
 The returned `AnnotatedTypeConfigurator` is initialized with type and annotations of the provided class.
+* `configureQualifier()` returns a new `AnnotatedTypeConfigurator` as defined in <<annotated_type_configurator>> to configure a new `AnnotatedType` and declares it as a qualifier type.
+* `configureInterceptorBinding()` returns a new `AnnotatedTypeConfigurator` as defined in <<annotated_type_configurator>> to configure a new `AnnotatedType` and declares it as an interceptor binding.
 
 
 [source, java]


### PR DESCRIPTION
CDI-642 Allow defining interceptor binding or qualifier with an AnnotatedTypeConfigurator