### PR TITLE
CDI-439 Clarify ProcessBean.getAnnotated()

### DIFF
--- a/api/src/main/java/javax/enterprise/inject/spi/ProcessBean.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ProcessBean.java
@@ -26,13 +26,14 @@ package javax.enterprise.inject.spi;
  * </p>
  * <ul>
  * <li>For a managed bean with bean class X, the container must raise an event of type
- * {@link javax.enterprise.inject.spi.ProcessManagedBean}<X>.</li>
+ * {@link javax.enterprise.inject.spi.ProcessManagedBean}.</li>
  * <li>For a session bean with bean class X, the container must raise an event of type
- * {@link javax.enterprise.inject.spi.ProcessSessionBean}<X>.</li>
+ * {@link javax.enterprise.inject.spi.ProcessSessionBean}.</li>
  * <li>For a producer method with method return type X of a bean with bean class T, the container must raise an event of type
- * {@link javax.enterprise.inject.spi.ProcessProducerMethod}<T, X>.</li>
+ * {@link javax.enterprise.inject.spi.ProcessProducerMethod}.</li>
  * <li>For a producer field with field type X of a bean with bean class T, the container must raise an event of type
- * {@link javax.enterprise.inject.spi.ProcessProducerField}<T, X>.</li>
+ * {@link javax.enterprise.inject.spi.ProcessProducerField}.</li>
+ * <li>For a custom implementation of {@link Bean}, the container must raise an event of type {@link ProcessSyntheticBean}.</li>
  * </ul>
  * <p>
  * Resources are considered to be producer fields.
@@ -47,10 +48,15 @@ package javax.enterprise.inject.spi;
  * @param <X> The class of the bean
  */
 public interface ProcessBean<X> {
+
     /**
      * Returns the {@link javax.enterprise.inject.spi.AnnotatedType} representing the bean class, the
      * {@link javax.enterprise.inject.spi.AnnotatedMethod} representing the producer method, or the
      * {@link javax.enterprise.inject.spi.AnnotatedField} representing the producer field.
+     * 
+     * <p>
+     * If invoked upon a {@link ProcessSyntheticBean} event, non-portable behavior results and the returned value should be ignored.
+     * </p>
      * 
      * @return the {@link javax.enterprise.inject.spi.AnnotatedType} for the bean being registered
      * @throws IllegalStateException if called outside of the observer method invocation
@@ -63,7 +69,7 @@ public interface ProcessBean<X> {
      * {@link javax.decorator.Decorator}.
      * 
      * @return the {@link javax.enterprise.inject.spi.Bean} object about to be registered
-     * @throws IllegalStateException if called outside of the observer method invocation     * 
+     * @throws IllegalStateException if called outside of the observer method invocation 
      */
     public Bean<X> getBean();
 

--- a/api/src/main/java/javax/enterprise/inject/spi/ProcessSyntheticBean.java
+++ b/api/src/main/java/javax/enterprise/inject/spi/ProcessSyntheticBean.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2016, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,  
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package javax.enterprise.inject.spi;
+
+/**
+ * <p>
+ * The container fires an event of this type for each custom bean implementation added through
+ * {@link AfterBeanDiscovery#addBean()} or {@link AfterBeanDiscovery#addBean(Bean)}, before registering the
+ * {@link javax.enterprise.inject.spi.Bean} object.
+ * </p>
+ * <p>
+ * If any observer method of a {@code ProcessSyntheticBean} event throws an exception, the exception is treated as a definition
+ * error by the container.
+ * </p>
+ * 
+ * @author Martin Kouba
+ * @param <X> The class of the bean
+ * @since 2.0
+ */
+public interface ProcessSyntheticBean<X> extends ProcessBean<X> {
+
+    /**
+     * Get the extension instance which added the {@link Bean} for which this event is being fired.
+     * 
+     * @return the extension instance
+     * @throws IllegalStateException if called outside of the observer method invocation
+     */
+    public Extension getSource();
+
+}

--- a/spec/src/main/asciidoc/core/spi.asciidoc
+++ b/spec/src/main/asciidoc/core/spi.asciidoc
@@ -1121,7 +1121,7 @@ public interface AfterBeanDiscovery {
 ----
 
 * `addDefinitionError()` registers a definition error with the container, causing the container to abort deployment after all observers have been notified.
-* `addBean()` fires an event of type `ProcessBean` containing the given `Bean` and then registers the `Bean` with the container, thereby making it available for injection into other beans.
+* `addBean()` fires an event of type `ProcessSyntheticBean` containing the given `Bean` and then registers the `Bean` with the container, thereby making it available for injection into other beans.
 The given `Bean` may implement `Interceptor` or `Decorator`.
 +
 The second version of the method, returns a new `BeanConfigurator` as defined in <<bean_configurator>> to easily configure the `Bean` which will be added at the end of observer invocation.
@@ -1463,7 +1463,7 @@ The event object type in the package `javax.enterprise.inject.spi` depends upon 
 * For a managed bean with bean class `X`, the container must raise an event of type `ProcessManagedBean<X>`.
 * For a producer method with method return type `T` of a bean with bean class `X`, the container must raise an event of type `ProcessProducerMethod<T, X>`.
 * For a producer field with field type `T` of a bean with bean class `X`, the container must raise an event of type `ProcessProducerField<T, X>`.
-
+* For a custom implementation of `Bean`, the container must raise an event of type `ProcessSyntheticBean<X>`.
 
 The interface `javax.enterprise.inject.spi.ProcessBean` is a supertype of all these event types:
 
@@ -1476,7 +1476,7 @@ public interface ProcessBean<X> {
 }
 ----
 
-* `getAnnotated()` returns the `AnnotatedType` representing the bean class, the `AnnotatedMethod` representing the producer method, or the `AnnotatedField` representing the producer field.
+* `getAnnotated()` returns the `AnnotatedType` representing the bean class, the `AnnotatedMethod` representing the producer method, or the `AnnotatedField` representing the producer field. If invoked upon a `ProcessSyntheticBean` event, non-portable behavior results and the returned value should be ignored.
 * `getBean()` returns the `Bean` object that is about to be registered.
 The `Bean` may implement `Interceptor` or `Decorator`.
 * `addDefinitionError()` registers a definition error with the container, causing the container to abort deployment after bean discovery is complete.
@@ -1505,6 +1505,14 @@ public interface ProcessProducerField<T, X>
         extends ProcessBean<X> {
     public AnnotatedField<T> getAnnotatedProducerField();
     public AnnotatedParameter<T> getAnnotatedDisposedParameter();
+}
+----
+
+[source, java]
+----
+public interface ProcessSyntheticBean<X>
+        extends ProcessBean<X> {
+    public Extension getSource();
 }
 ----
 


### PR DESCRIPTION
- also introduce `ProcessSyntheticBean` (allows to filter custom bean impls added through `AfterBeanDiscovery.addBean()`)