### PR TITLE
CDI-232 Loosen the requirement of Instance and Provider to only match injection points.

### DIFF
--- a/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
+++ b/spec/src/main/asciidoc/core/injectionandresolution.asciidoc
@@ -751,14 +751,13 @@ An `UnsupportedOperationException` is thrown if the active context object for th
 
 ==== The built-in `Instance`
 
-The container must provide a built-in bean with:
+For each injection point of `Instance<?>` or `Provider<?>`, the container must provide a built-in bean that satisfies:
 
 * `Instance<X>` and `Provider<X>` for every legal bean type `X` in its set of bean types,
 * every qualifier type in its set of qualifier types,
 * scope `@Dependent`,
 * no bean name, and
 * an implementation provided automatically by the container.
-
 
 The built-in implementation must be a passivation capable dependency, as defined in <<passivation_capable_dependency>>.
 


### PR DESCRIPTION
I believe we spoke about this on some medium, I suspect IRC, some while ago.  Where we left is that the container only has to support beans being installed that match the injection points identified, not beans for Instances that had no injection targets.

As a result, I reworded the first line only to clarify this and rephrase it to make the reading into the bullets cleaner (in my opinion).  