### PR TITLE
CDI-699 AnnotationLiteral should use privileged actions for reflective operations

### DIFF
--- a/api/src/main/java/javax/enterprise/util/SecurityActions.java
+++ b/api/src/main/java/javax/enterprise/util/SecurityActions.java
@@ -1,0 +1,60 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.1-SNAPSHOT (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.1-SNAPSHOT
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package javax.enterprise.util;
+
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+/**
+ *
+ * This utility class is used to optimize invocation made through the SecurityManager
+ *
+ * @author Antoine Sabot-durand
+ */
+
+final class SecurityActions {
+
+    private SecurityActions() {
+
+    }
+
+    static void setAccessible(Method method) {
+        if (System.getSecurityManager() != null) {
+            AccessController.doPrivileged(
+                    (PrivilegedAction<?>) () -> {
+                        method.setAccessible(true);
+                        return null;
+                    }
+            );
+        } else {
+            method.setAccessible(true);
+        }
+    }
+
+
+    static Method[] getDeclaredMethods(Class<?> clazz) {
+        if (System.getSecurityManager() != null) {
+            return AccessController.doPrivileged(
+                    (PrivilegedAction<Method[]>) () -> clazz.getDeclaredMethods()
+            );
+        } else {
+            return clazz.getDeclaredMethods();
+        }
+    }
+}

--- a/api/src/test/java/org/jboss/cdi/api/test/privileged/annotation/AnnotationLiteralTest.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/privileged/annotation/AnnotationLiteralTest.java
@@ -1,0 +1,55 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.cdi.api.test.privileged.annotation;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ *
+ * This class test usage of privileged bloc in {@link javax.enterprise.util.AnnotationLiteral}
+ * They launched with Java security Manager.
+ *
+ * @author Antoine Sabot-Durand
+ *
+ */
+public class AnnotationLiteralTest {
+
+    @Test
+    public void toStringShouldWork() {
+        Assert.assertNotNull(mal.toString());
+    }
+
+    @Test
+    public void annotationTypeShouldWork() {
+        Assert.assertEquals(MyAnnotation.class, mal.annotationType());
+    }
+
+    @Test
+    public void equalsShouldWork() {
+        MyAnnotationLiteral mal2 = new MyAnnotationLiteral("hello", 42);
+        Assert.assertEquals(mal, mal2);
+    }
+
+    @Test
+    public void hashCodeShouldWork() {
+        Assert.assertNotEquals(0, mal.hashCode());
+    }
+
+    private static final MyAnnotationLiteral mal = new MyAnnotationLiteral("hello", 42);
+}

--- a/api/src/test/java/org/jboss/cdi/api/test/privileged/annotation/MyAnnotation.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/privileged/annotation/MyAnnotation.java
@@ -1,0 +1,32 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.cdi.api.test.privileged.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD, ElementType.PARAMETER})
+public @interface MyAnnotation {
+
+    public String member1() default "member1";
+
+    public int member2() default 2;
+}

--- a/api/src/test/java/org/jboss/cdi/api/test/privileged/annotation/MyAnnotationLiteral.java
+++ b/api/src/test/java/org/jboss/cdi/api/test/privileged/annotation/MyAnnotationLiteral.java
@@ -1,0 +1,44 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2018, Red Hat, Inc., and individual contributors
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.jboss.cdi.api.test.privileged.annotation;
+
+import javax.enterprise.util.AnnotationLiteral;
+
+public class MyAnnotationLiteral extends AnnotationLiteral<MyAnnotation> implements MyAnnotation {
+
+    public MyAnnotationLiteral(String m1, int m2) {
+        this.m1 = m1;
+        this.m2 = m2;
+    }
+
+    @Override
+    public String member1() {
+        return m1;
+    }
+
+    @Override
+    public int member2() {
+        return m2;
+    }
+
+    private String m1;
+
+    private int m2;
+
+
+}


### PR DESCRIPTION
Addition of privileged bloc in AnnotationLiteral