### PR TITLE
use testRources for filtering of src/test/resources in cdi-api

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -250,13 +250,12 @@
 	</profiles>
 
 	<build>
-		<resources>
-			<resource>
+		<testResources>
+			<testResource>
 				<filtering>true</filtering>
 				<directory>src/test/resources</directory>
-				<targetPath>${project.build.testOutputDirectory}</targetPath>
-			</resource>
-		</resources>
+			</testResource>
+		</testResources>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.felix</groupId>


### PR DESCRIPTION
prevent adding files to source jar from folder target/test-classes with absolute path

currently source jar files contains entries with absolute path (entries starting with /) which does not make sense and causes failure of javadocs referencing cdi-api-2.0.SP1-sources.jar

        0  07-13-2018 18:18   /
        0  05-27-2018 08:56   /Users/
        0  07-19-2018 16:31   /Users/antoine/
        0  06-26-2018 14:05   /Users/antoine/dev/
        0  06-16-2017 09:09   /Users/antoine/dev/cdi/
        0  07-19-2018 16:31   /Users/antoine/dev/cdi/cdi-spec/
        0  07-19-2018 16:31   /Users/antoine/dev/cdi/cdi-spec/api/
        0  07-19-2018 16:31   /Users/antoine/dev/cdi/cdi-spec/api/target/
        0  07-19-2018 16:31   /Users/antoine/dev/cdi/cdi-spec/api/target/test-classes/
        0  01-04-2017 17:34   /Users/antoine/dev/cdi/cdi-spec/api/target/test-classes/META-INF/
        0  07-19-2018 13:27   /Users/antoine/dev/cdi/cdi-spec/api/target/test-classes/META-INF/services/
      816  07-19-2018 16:31   /Users/antoine/dev/cdi/cdi-spec/api/target/test-classes/full-beans-1_1.xml
       49  07-19-2018 13:27   /Users/antoine/dev/cdi/cdi-spec/api/target/test-classes/META-INF/services/fake
        0  01-04-2017 17:34   /Users/antoine/dev/cdi/cdi-spec/api/target/test-classes/META-INF/services/dummy
     3194  07-19-2018 13:27   /Users/antoine/dev/cdi/cdi-spec/api/target/test-classes/java.policy


to produce above zip run in shell
(cd /tmp/; wget http://repo1.maven.org/maven2/javax/enterprise/cdi-api/2.0.SP1/cdi-api-2.0.SP1-sources.jar ; unzip -l cdi-api-2.0.SP1-sources.jar | grep "   /")

  